### PR TITLE
Add support for Galaxy Camera

### DIFF
--- a/rm_vision_bringup/launch/vision_bringup.launch.py
+++ b/rm_vision_bringup/launch/vision_bringup.launch.py
@@ -46,11 +46,14 @@ def generate_launch_description():
 
     hik_camera_node = get_camera_node('hik_camera', 'hik_camera::HikCameraNode')
     mv_camera_node = get_camera_node('mindvision_camera', 'mindvision_camera::MVCameraNode')
+    galaxy_camera_node = get_camera_node('galaxy_camera', 'galaxy_camera::GalaxyCameraNode')
 
     if (launch_params['camera'] == 'hik'):
         cam_detector = get_camera_detector_container(hik_camera_node)
     elif (launch_params['camera'] == 'mv'):
         cam_detector = get_camera_detector_container(mv_camera_node)
+    elif (launch_params['camera'] == 'galaxy'):
+        cam_detector = get_camera_detector_container(galaxy_camera_node)
 
     serial_driver_node = Node(
         package='rm_serial_driver',


### PR DESCRIPTION
Use 'galaxy' for camera config.

Needs to be used with https://github.com/RigoLigoRLC/rm_vision_ros2_galaxy_camera . Clone and put this repo in the same workspace, parallel to your camera drivers, and build & run the workspace as usual.

Not fully tested and experimental. Issue reports welcomed.